### PR TITLE
Add config option for flattening per profile directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ return [
         # overwrite original date pattern - `/2020/10/30/img.jpg` --> `/images/img.jpg`
         'customFolder' => '/images',    # (string|null) default: null
 
+		# String to use to separate the profile name from the file name
+		# Defaults to false, which will generate a directory per profile, eg: /small/img.jpg
+		# If specified, files will exist in single directory, eg /img@small.jpg
+		'profileNameSeparator' => '@', # (string|null) default: null
+
         # Spatie image optimizer (requires additional binaries)
         'optimize'     => true,         # (bool) default: false
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -74,6 +74,7 @@ $this->module('imageresize')->extend([
                     'optimize'     => false,      # Use Spatie optimizer
                     'replaceAssetsManager' => false,   # modified assets manager
                     'syncFileNamesWithTitle' => false, # set file name to sluggified title (experimental)
+                    'profileNameSeparator'   => null, # use a directory per profile, rather than modifying file name
                 ],
                 $this->app->storage->getKey('cockpit/options', 'imageresize', []),
                 $this->app->retrieve('imageresize', [])
@@ -285,11 +286,16 @@ $this->module('imageresize')->extend([
         $width  = $c['width']  ? $c['width']  : $asset['width'];
         $height = $c['height'] ? $c['height'] : $asset['height'];
 
-        $dir = !empty($c['folder']) ? $c['folder'] : $name;
-        $dir = '/'.\trim($dir, '/').'/';
+        $profile_name = !empty($c['folder']) ? $c['folder'] : $name;
         $file_name = \basename($asset['path']);
 
-        $destination = "{$dir}{$file_name}";
+        if($this->config['profileNameSeparator']) {
+            $parts = pathinfo($file_name);
+            $destination = "{$parts['filename']}{$this->config['profileNameSeparator']}{$profile_name}.{$parts['extension']}";
+        } else {
+            $dir = '/'.\trim($profile_name, '/').'/';
+            $destination = "{$dir}{$file_name}";
+        }
 
         if (!$rebuild && $this->app->filestorage->has("assets://{$destination}")) {
             return false;


### PR DESCRIPTION
This PR adds a config controlled ability to flatten the hierachy of per-profile folders into a single folder, eg, (assuming customFolder is set to "/images") rather than:

- `/images/small/img.jpg`
- `/images/large/img.jpg`
- `/images/img.jpg`

It is now possible to generate the following files:

- `/images/img@small.jpg`
- `/images/img@large.jpg`
- `/images/img.jpg`

This is achieved with a new config option, `profileNameSeparator` which controls the character (or string) used to seperate the file name from the profile name suffix.

This defaults to null, which uses the existing behaviour of a directory per profile.

------------

Note that if `keepOriginal` is set, the original file is still placed into a seperate directory.

