### PR TITLE
Allow optional profile generation based on asset size

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ return [
                 'quality' => 70,
                 # set custom folder, that doesn't match profile name --> `/header/img.jpg`
                 'folder'  => 'header'   # (string) if omited, the key name 'headerimage' is used
+				# skip generation if input asset is smaller than the width or height of this profile
+				'skipIfSmaller' => true,
             ],
         ],
     ],

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -285,6 +285,15 @@ $this->module('imageresize')->extend([
         $width  = $c['width']  ? $c['width']  : $asset['width'];
         $height = $c['height'] ? $c['height'] : $asset['height'];
 
+        if ($c['skipIfSmaller']) {
+            if (
+                ($asset['width'] <  $width || $asset['height'] <  $height) &&
+                ($asset['width'] <= $width && $asset['height'] <= $height)
+            ) {
+                return;
+            }
+        }
+
         $dir = !empty($c['folder']) ? $c['folder'] : $name;
         $dir = '/'.\trim($dir, '/').'/';
         $file_name = \basename($asset['path']);


### PR DESCRIPTION
Adds ability to skip generation of certain profiles when the size of the input asset is smaller than the size of image that the profile is intended to generate.

This is useful to have a series of standard image sizes, but only generate the ones which are smaller than the input asset:

```
'profiles' => [
    '4x' => [
        'width'         => 1920,
        'height'        => 0,
        'method'        => 'bestFit',
        'quality'       => 90,
        'skipIfSmaller' => true,
    ],
    '3x' => [
        'width'         => 1440,
        'height'        => 0,
        'method'        => 'bestFit',
        'quality'       => 90,
        'skipIfSmaller' => true,
    ],
    '2x' => [
        'width'         => 960,
        'height'        => 0,
        'method'        => 'bestFit',
        'quality'       => 90,
        'skipIfSmaller' => true,
    ],
    '1x' => [
        'width'         => 480,
        'height'        => 0,
        'method'        => 'bestFit',
        'quality'       => 90,
        'skipIfSmaller' => true,
    ],
],
```